### PR TITLE
Registered mask as a parameter without grad in CustomizedLinear

### DIFF
--- a/CustomizedLinear.py
+++ b/CustomizedLinear.py
@@ -81,6 +81,7 @@ class CustomizedLinear(nn.Module):
         else:
             self.mask = torch.tensor(mask, dtype=torch.float).t()
 
+        self.mask = nn.Parameter(self.mask, requires_grad=False)
 
         # nn.Parameter is a special kind of Tensor, that will get
         # automatically registered as Module's parameter once it's assigned


### PR DESCRIPTION
By registering the mask as a parameter, it won't require the user to move it manually to the GPU in case they're using one.